### PR TITLE
Fix for X11 Display Issue on Linux

### DIFF
--- a/sample_pyhidra.py
+++ b/sample_pyhidra.py
@@ -2,6 +2,7 @@ import pyghidra
 
 # Section to make autocomplete work
 try:
+    import os
     import ghidra
     from ghidra_builtins import *
 except:
@@ -10,6 +11,8 @@ except:
 
 PROJECT_NAME = 'sample_pyghidra'
 PROJECT_LOCATION = '.ghidra_projects'
+
+os.environ["JAVA_TOOL_OPTIONS"] = "-Djava.awt.headless=true"
 
 pyghidra.start(True)  # setting Verbose output
 


### PR DESCRIPTION
The X11 Display variable for certain Linux systems if not run in headless mode can cause an error.

Setting `JAVA_TOOL_OPTIONS` to `-Djava.awt.headless=true` should fix this error as it will not look for a display since we are not using one here.

https://www.oracle.com/technical-resources/articles/javase/headless.html

